### PR TITLE
kill fmt watcher task

### DIFF
--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectTasksOptions">
-    <TaskOptions isEnabled="true">
+    <TaskOptions isEnabled="false">
       <option name="arguments" value="fmt $FileName$" />
       <option name="checkSyntaxErrors" value="true" />
       <option name="description" />


### PR DESCRIPTION
It's buggy, causing reformats while working on files.