### PR TITLE
more elegant import.meta.url fix

### DIFF
--- a/web/import-meta-url-shim.js
+++ b/web/import-meta-url-shim.js
@@ -1,0 +1,2 @@
+const importMetaUrlShim = location.href;
+export { importMetaUrlShim as "import.meta.url" };


### PR DESCRIPTION
Since Firefox doesn't support ESM in web workers, it also doesn't support import.meta.url. We need to replace it when packaging our web worker. We've been doing that by having a subsequent build step that replaces import_meta.url (created for us by esbuild) with location.href.

This PR instead does the replacement of import.meta.url with location.href using the API provided by esbuild. This is a bit more elegant, and avoids a nasty console warning.