### PR TITLE
Improved performance with outlined subtitles:

### DIFF
--- a/deno/extract-image.ts
+++ b/deno/extract-image.ts
@@ -9,11 +9,12 @@ export async function extractImage(
   sup: Uint8Array,
   imageIndex: number,
   outWriter: Deno.Writer,
+  outlineFlag: string,
 ) {
   const result = parse(sup);
   const basicParsed = pgsSchema.parse(result);
   const parsedSegments = basicParsed.segment;
-  const groupedSegments = packetize(parsedSegments);
+  const groupedSegments = packetize(parsedSegments, outlineFlag);
   const unrendered = iterOds(groupedSegments);
   // now get ods number whatever
   let subIndex = 1;
@@ -35,3 +36,4 @@ export async function extractImage(
   });
   await writeAll(outWriter, bmp.data);
 }
+

--- a/deno/main.ts
+++ b/deno/main.ts
@@ -39,14 +39,13 @@ async function main(
       relativePath(buildConfig.workerBundle),
     ];
 
-  const [trainedDataPathOrIndex, supPath] = args;
+  const [trainedDataPathOrIndex, supPath, outlineFlag] = args;
 
   const supReader = supPath === "-" ? inReader : await Deno.open(supPath);
 
   // it feels kind of stupid that we don't support streaming this,
   // but these files tend to be in the tens of megabytes
   const sup = await readAll(supReader);
-
   const index = parseInt(trainedDataPathOrIndex, 10);
   return isNaN(index)
     ? runConvert(sup, {
@@ -55,8 +54,9 @@ async function main(
       workerPath,
       outWriter,
       errWriter,
+      outlineFlag,
     })
-    : extractImage(sup, index, outWriter);
+    : extractImage(sup, index, outWriter, outlineFlag);
 }
 
 function isDev(): boolean {
@@ -69,3 +69,4 @@ function relativePath(p: string): string {
   const mainDir = path.dirname(path.fromFileUrl(Deno.mainModule));
   return path.join(mainDir, p);
 }
+

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -15,11 +15,12 @@ export async function* pipeline(
   workerURL: URL,
   wasmBinary: Uint8Array,
   trainedData: Uint8Array,
+  outlineFlag: string,
 ): AsyncGenerator<[Progress, string], number[]> {
   const result = parse(pgs);
   const basicParsed = pgsSchema.parse(result);
   const parsedSegments = basicParsed.segment;
-  const groupedSegments = packetize(parsedSegments);
+  const groupedSegments = packetize(parsedSegments, outlineFlag);
   const unrendered = iterOds(groupedSegments);
   const [toBeRendered, toCount] = tee(unrendered, 2);
   let total = 0;
@@ -37,3 +38,4 @@ export async function* pipeline(
   }
   return next.value;
 }
+


### PR DESCRIPTION
Some PGS subtitles are written as black/grey text with white outlines.

![outline](https://github.com/user-attachments/assets/0e26b042-1112-451a-ab02-b5482aeaeb14)

I believe this confuses Tesseract, and the results are really poor:

```
00:01:25,586 --> 00:01:28,130
Seams to me that
love [is everwhere.
```

I found that in these situations, tweaking how the bitmaps are rendered greatly improves accuracy:
![nooutline](https://github.com/user-attachments/assets/098c54c8-6b17-49fe-bba6-034c2ab90720)


```
00:01:25,586 --> 00:01:28,130
Seems to me that
love is everywhere.
```

I also added some code which changes all instances of "|" to "I" since vertical bars are uncommon and Tesseract seems to really like them.

It's still not perfect. It omits entire lines for some reason occasionally, and there are still a lot of Is showing up as square brackets, but I think it's a good start.

The feature is implemented as a command line argument of "outline" that can be appended onto the tail of either SRT conversion or bitmap export.

I'm still a n00b at contributing on github, so this is humbly submitted.